### PR TITLE
updating rstudio caddy configuration

### DIFF
--- a/drone/site/Caddyfile
+++ b/drone/site/Caddyfile
@@ -11,6 +11,7 @@ drone.carlboettiger.info {
   proxy /rstudio rstudio:8787 {
     without /rstudio
     header_upstream Host {host}/rstudio
+    websocket
     transparent
   }
   redir /rstudio /rstudio/ 307

--- a/milad/site/Caddyfile
+++ b/milad/site/Caddyfile
@@ -4,6 +4,8 @@ milad.carlboettiger.info {
 
   proxy / rstudio:8787 {
     header_upstream Host {host}
+    websocket
+    transparent
   }
 
 }

--- a/rstudio/site/Caddyfile
+++ b/rstudio/site/Caddyfile
@@ -3,6 +3,7 @@ rstudio.carlboettiger.info {
   tls cboettig@gmail.com
 
   proxy / rstudio:8787 {
+    websocket
     transparent
   }
 

--- a/rstudio/site/Caddyfile
+++ b/rstudio/site/Caddyfile
@@ -3,6 +3,7 @@ rstudio.carlboettiger.info {
   tls cboettig@gmail.com
 
   proxy / rstudio:8787 {
+    header_upstream Host {host}
     websocket
     transparent
   }


### PR DESCRIPTION
Carl, Thanks for the tip about this repo. This PR represents adding websocket upgrades to rstudio, which allows the terminal to be used.

Without the websocket upgrade, when accessing the terminal, get an error

```
Websocket connection error, switching to RPC
Unable to switch back to RPC mode
```

I have also normalized the host header passthrough. I am not sure if this is needed when at the root, as I think the `transparent` directive is providing this already, however there is something to be said for consistency. 

Feel free to accept/reject/cherrypick anything from this PR, just wanted to give back.